### PR TITLE
Terraform Deploy Script Fix:

### DIFF
--- a/Scenarios/Secure-Baseline/terraform/deploy.azcli
+++ b/Scenarios/Secure-Baseline/terraform/deploy.azcli
@@ -19,6 +19,12 @@ echo "Enter the Name of the Service Principal for ARO to use:"
 read -r SPNNAME
 echo "Enter the Subscription ID where you want ARO deployed:"
 read -r SUBSCRIPTIONID
+echo "Enter the ARO cluster base name"
+read -r AROBASENAME
+echo "Enter the ARO Domain"
+read -r ARO_DOMAIN
+
+TENANT_ID=$(az account show -s ${SUBSCRIPTIONID} --query tenantId -o tsv)
 
 # Create the Service Principal
 # TODO: Add check to see if the SPN already exists
@@ -27,23 +33,23 @@ az ad sp create-for-rbac --name $SPNNAME --scopes /subscriptions/$SUBSCRIPTIONID
 # Set variables from the Service Principal
 SP_CLIENT_ID=$(jq -r '.appId' /tmp/sp.json)
 SP_CLIENT_SECRET=$(jq -r '.password' /tmp/sp.json)
-SP_OBJECT_ID=$(az ad sp show --id $SP_CLIENT_ID | jq -r '.id')
 
 # Set variable for ARO Provider SP Object ID
-ARO_SP_OBJECT_ID=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query "[0].id" -o tsv)
+ARO_RP_SP_OBJECT_ID=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" --query "[0].objectId" -o tsv)
 
 ### Deploy Environment ###
 # Initialize Terraform
 terraform init
 
 # Terraform Apply
-terraform apply \
-  -auto-approve \
-  -var tenant_id="$SPNAME" \
+terraform plan \
+  -var tenant_id="$TENANT_ID" \
   -var subscription_id="$SUBSCRIPTIONID" \
-  -var aro_sp_object_id="$SP_OBJECT_ID" \
+  -var aro_sp_client_id="$SP_CLIENT_ID" \
   -var aro_sp_password="$SP_CLIENT_SECRET" \
-  -var aro_rp_object_id="$ARO_RP_SP_OBJECT_ID"
+  -var aro_rp_object_id="$ARO_RP_SP_OBJECT_ID" \
+  -var aro_base_name="$AROBASENAME" \
+  -var aro_domain="$ARODOMAIN"
 
 # Inform user that additional steps are required to complete the deployment. These must be completed from the JumpBox.
 echo "Additional steps are required to complete the deployment. These must be completed from the JumpBox. Please consult the readme file"

--- a/Scenarios/Secure-Baseline/terraform/deploy.azcli
+++ b/Scenarios/Secure-Baseline/terraform/deploy.azcli
@@ -22,7 +22,7 @@ read -r SUBSCRIPTIONID
 echo "Enter the ARO cluster base name"
 read -r AROBASENAME
 echo "Enter the ARO Domain"
-read -r ARO_DOMAIN
+read -r ARODOMAIN
 
 TENANT_ID=$(az account show -s ${SUBSCRIPTIONID} --query tenantId -o tsv)
 
@@ -42,7 +42,8 @@ ARO_RP_SP_OBJECT_ID=$(az ad sp list --display-name "Azure Red Hat OpenShift RP" 
 terraform init
 
 # Terraform Apply
-terraform plan \
+terraform apply \
+  --auto-approve \
   -var tenant_id="$TENANT_ID" \
   -var subscription_id="$SUBSCRIPTIONID" \
   -var aro_sp_client_id="$SP_CLIENT_ID" \

--- a/Scenarios/Secure-Baseline/terraform/main.tf
+++ b/Scenarios/Secure-Baseline/terraform/main.tf
@@ -61,6 +61,8 @@ module "supporting" {
   hub_vnet_id                = module.vnet.hub_vnet_id
   spoke_vnet_id              = module.vnet.spoke_vnet_id
   private_endpoint_subnet_id = module.vnet.private_endpoint_subnet_id
+  spoke_rg_name = azurerm_resource_group.spoke.name
+  hub_rg_name = azurerm_resource_group.hub.name
 
   depends_on = [
     module.vnet
@@ -76,9 +78,12 @@ module "aro" {
   master_subnet_id = module.vnet.master_subnet_id
   worker_subnet_id = module.vnet.worker_subnet_id
 
-  aro_sp_object_id = var.aro_sp_object_id
+  aro_sp_client_id = var.aro_sp_client_id
   aro_sp_password = var.aro_sp_password
   aro_rp_object_id = var.aro_rp_object_id
+  spoke_rg_name = azurerm_resource_group.spoke.name
+  base_name = var.aro_base_name
+  domain = var.aro_domain
 
   depends_on = [
     module.vnet
@@ -92,6 +97,8 @@ module "frontdoor" {
   aro_worker_subnet_id = module.vnet.worker_subnet_id
   la_id = azurerm_log_analytics_workspace.la.id
   random = random_string.random.result
+  aro_resource_group_name = module.aro.cluster_resource_group_name
+  spoke_rg_name = azurerm_resource_group.spoke.name
   
   depends_on = [
     module.aro
@@ -104,4 +111,5 @@ module "containerinsights" {
   location = azurerm_log_analytics_workspace.la.location
   workspace_resource_id = azurerm_log_analytics_workspace.la.id
   workspace_name = azurerm_log_analytics_workspace.la.name
+  spoke_rg_name = azurerm_resource_group.hub.name
 }

--- a/Scenarios/Secure-Baseline/terraform/modules/aro/aro.tf
+++ b/Scenarios/Secure-Baseline/terraform/modules/aro/aro.tf
@@ -16,7 +16,7 @@ resource "azurerm_resource_group_template_deployment" "aro" {
   deployment_mode = "Incremental"
   parameters_content = jsonencode({
     "clientId" = {
-      value = var.aro_sp_object_id    }
+      value = var.aro_sp_client_id    }
     "clientSecret" = {
       value = var.aro_sp_password
     }
@@ -27,7 +27,7 @@ resource "azurerm_resource_group_template_deployment" "aro" {
       value = "openshift-cluster-${var.base_name}"
     }
     "domain" = {
-      value = "ratingsapp.${var.base_name}.com"
+      value = "${var.domain}"
     }
     "location" = {
       value = var.location

--- a/Scenarios/Secure-Baseline/terraform/modules/aro/aro_outputs.tf
+++ b/Scenarios/Secure-Baseline/terraform/modules/aro/aro_outputs.tf
@@ -1,0 +1,3 @@
+output cluster_resource_group_name {
+    value = "openshift-cluster-${var.base_name}"
+}

--- a/Scenarios/Secure-Baseline/terraform/modules/aro/aro_variables.tf
+++ b/Scenarios/Secure-Baseline/terraform/modules/aro/aro_variables.tf
@@ -11,6 +11,10 @@ variable "base_name" {
   default = "aro"
 }
 
+variable "domain" {
+  type = string
+}
+
 variable "spoke_rg_name" {
   type = string
   default = "spoke-aro"
@@ -32,7 +36,7 @@ variable "location" {
   type = string
 }
 
-variable "aro_sp_object_id" {
+variable "aro_sp_client_id" {
   type = string
 }
 

--- a/Scenarios/Secure-Baseline/terraform/modules/vm/vm.tf
+++ b/Scenarios/Secure-Baseline/terraform/modules/vm/vm.tf
@@ -80,7 +80,7 @@ resource "azurerm_virtual_machine_extension" "jumpbox" {
 
   settings = <<SETTINGS
   {
-    "fileUris": ["https://raw.githubusercontent.com/Azure/ARO-Landing-Zone-Accelerator/terraform/deployment/terraform/modules/vm/start_script.ps1?token=GHSAT0AAAAAABXBWKU65G3ZBU46JIP2TN3QYX5PMDQ"],
+    "fileUris": ["https://raw.githubusercontent.com/Azure/ARO-Landing-Zone-Accelerator/main/Scenarios/Secure-Baseline/terraform/modules/vm/start_script.ps1"],
     "commandToExecute": "powershell -ExecutionPolicy Unrestricted -File start_script.ps1"
   }
   SETTINGS

--- a/Scenarios/Secure-Baseline/terraform/modules/vnet/firewall.tf
+++ b/Scenarios/Secure-Baseline/terraform/modules/vnet/firewall.tf
@@ -501,6 +501,14 @@ resource "azurerm_monitor_diagnostic_setting" "fw_diag" {
       enabled = false
     }
   }
+  log {
+    category = "AZFWFatFlow"
+    enabled = false
+    retention_policy {
+      days = 0
+      enabled = false
+    }
+  }
 
   metric {
   category = "AllMetrics"

--- a/Scenarios/Secure-Baseline/terraform/variables.tf
+++ b/Scenarios/Secure-Baseline/terraform/variables.tf
@@ -55,7 +55,7 @@ resource "random_string" "random" {
   }
 }
 
-variable "aro_sp_object_id" {
+variable "aro_sp_client_id" {
   type = string
 }
 
@@ -64,5 +64,13 @@ variable "aro_sp_password" {
 }
 
 variable "aro_rp_object_id" {
+  type = string
+}
+
+variable "aro_base_name" {
+  type = string
+}
+
+variable "aro_domain" {
   type = string
 }


### PR DESCRIPTION
    Use Correct Tenant ID instead of Service Principal Name
    Use SP CLIENT ID for ARO cluster service principal instead of object id
    Correct Resource Principal Query Function
    Fix the outdated jumpbox extention URL
Make the terraform more usable instead of hard coded:
    Make the Resource Group Names Configurable
    Make the ARO Cluster Names Configurable
    Make the ARO Cluster Domain Configurable
Make the terraform consistant during reapplying
    Add default diagnostic setting AZFWFatFlow