### PR TITLE
Add dev container definition for ARO LZA development and to manage ARO cluster

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,63 @@
+{
+    "name": "ARO LZA Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+      "ghcr.io/devcontainers/features/azure-cli:1": {},
+      "ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1": {},
+      "ghcr.io/devcontainers/features/terraform:1": {},
+      "ghcr.io/devcontainers-contrib/features/terrascan:1": {},
+      "ghcr.io/devcontainers/features/dotnet:2": {},
+      "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+      "ghcr.io/paul-gilber/devcontainer-features/openshift-cli-homebrew:1": {}
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-azuretools.vscode-bicep",
+          "eamodio.gitlens",
+          "github.copilot",
+          "github.copilot-chat",
+          "gruntfuggly.todo-tree",
+          "github.vscode-github-actions",
+          "github.vscode-pull-request-github",
+          "hashicorp.terraform",
+          "helixquar.asciidecorator",
+          "humao.rest-client",
+          "joffreykern.markdown-toc",
+          "mhutchie.git-graph",
+          "ms-azure-devops.azure-pipelines",
+          "ms-azurecache.vscode-azurecache",
+          "ms-azuretools.azure-dev",
+          "ms-azuretools.vscode-apimanagement",
+          "ms-azuretools.vscode-azureappservice",
+          "ms-azuretools.vscode-azurecontainerapps",
+          "ms-azuretools.vscode-azurefunctions",
+          "ms-azuretools.vscode-azurelogicapps",
+          "ms-azuretools.vscode-azureresourcegroups",
+          "ms-azuretools.vscode-azurestaticwebapps",
+          "ms-azuretools.vscode-azurestorage",
+          "ms-azuretools.vscode-azureterraform",
+          "ms-azuretools.vscode-azurevirtualmachines",
+          "ms-azuretools.vscode-bicep",
+          "ms-azuretools.vscode-cosmosdb",
+          "ms-azuretools.vscode-dapr",
+          "ms-azuretools.vscode-docker",
+          "ms-azuretools.vscode-logicapps",
+          "ms-bigdatatools.vscode-asa",
+          "ms-kubernetes-tools.vscode-aks-tools",
+          "ms-kubernetes-tools.vscode-kubernetes-tools",
+          "ms-vscode.azure-account",
+          "ms-vscode.azure-repos",
+          "ms-vscode.azurecli",
+          "msazurermtools.azurerm-vscode-tools",
+          "redhat.vscode-xml",
+          "redhat.vscode-yaml",
+          "stackbreak.comment-divider"
+        ]
+      }
+    },
+    "forwardPorts": [
+      // Forward ports if needed for local development
+    ],
+    "postCreateCommand": ""
+  }


### PR DESCRIPTION
This pull request includes a significant change to the `.devcontainer/devcontainer.json` file. The change introduces a new `ARO LZA Dev Container` with specific features and customizations for the development environment. 

The most important changes are:

* Addition of a new dev container configuration named `ARO LZA Dev Container`. This container is based on the `mcr.microsoft.com/devcontainers/base:ubuntu` image.
* Inclusion of several features to the dev container, such as `azure-cli`, `azurebicep`, `terraform`, `terrascan`, `dotnet`, `kubectl-helm-minikube`, and `openshift-cli-homebrew`. These features are provided by different contributors and are versioned.
* Customizations for Visual Studio Code have been added, which include a long list of extensions that will be installed in the dev container. These extensions range from Azure tools, Git utilities, to various language support and formatting tools.
* The `forwardPorts` field is included for potential local development needs, but no specific ports are forwarded at this time.
* The `postCreateCommand` field is included but left empty, indicating there are no commands to be run after the creation of the dev container.