### PR TITLE
Refactor key vault types in Supporting Services

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/03-Supporting-Services/modules/key-vault/types.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/03-Supporting-Services/modules/key-vault/types.bicep
@@ -2,6 +2,18 @@
 @description('The SKU of the key vault.')
 type skuType = 'standard' | 'premium'
 
+@description('Defines the rotation policy for a key.')
+type rotationPolicyType = {
+  @description('The attributes of the rotation policy.')
+  attributes: {
+    @description('The expiration time for the new key version. It should be in ISO8601 format. Eg: \'P90D\', \'P1Y\'.')
+    expiryTime: string
+  }
+
+  @description('The lifetime actions for the rotation policy.')
+  lifetimeActions: lifetimeActionType[]
+}
+
 @export()
 type keyType = {
   @description('The name of the key.')
@@ -17,23 +29,17 @@ type keyType = {
   attributesNbf: int?
   
   @description('The elliptic curve name.')
-  curveName: curveNameType?
+  curveName: 'P-256' | 'P-256K' | 'P-384' | 'P-521'?
   
   @description('The key size in bits. For example: 2048, 3072, or 4096 for RSA.')
   keySize: 2048 | 3072 | 4096 | null
 
   @description('The type of the key.')
-  kty: ktyType
+  kty: 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM'
 
   @description('The key rotation policy.')
   rotationPolicy: rotationPolicyType?
 }
-
-@description('The type of the key.')
-type ktyType = 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM'
-
-@description('The elliptic curve name.')
-type curveNameType = 'P-256' | 'P-256K' | 'P-384' | 'P-521'
 
 @description('Defines the attributes for the rotation policy')
 type rotationPolicyAttributesType = {
@@ -62,11 +68,4 @@ type lifetimeActionType = {
   trigger: lifetimeActionTriggerType
 }
 
-@description('Defines the rotation policy for a key')
-type rotationPolicyType = {
-  @description('The attributes of the rotation policy')
-  attributes: rotationPolicyAttributesType
 
-  @description('The lifetime actions for the rotation policy')
-  lifetimeActions: lifetimeActionType[]
-}

--- a/Scenarios/Secure-Baseline/bicepWithAVM/03-Supporting-Services/modules/key-vault/types.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/03-Supporting-Services/modules/key-vault/types.bicep
@@ -3,14 +3,6 @@
 type skuType = 'standard' | 'premium'
 
 @export()
-@description('The elliptic curve name.')
-type curveNameType = 'P-256' | 'P-256K' | 'P-384' | 'P-521'
-
-@export()
-@description('The type of the key.')
-type ktyType = 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM'
-
-@export()
 type keyType = {
   @description('The name of the key.')
   name: string
@@ -20,13 +12,13 @@ type keyType = {
   
   @description('Expiry date in seconds since 1970-01-01T00:00:00Z.')
   attributesExp: int?
-
+  
   @description('Not before date in seconds since 1970-01-01T00:00:00Z.')
   attributesNbf: int?
-
+  
   @description('The elliptic curve name.')
   curveName: curveNameType?
-
+  
   @description('The key size in bits. For example: 2048, 3072, or 4096 for RSA.')
   keySize: 2048 | 3072 | 4096 | null
 
@@ -34,5 +26,47 @@ type keyType = {
   kty: ktyType
 
   @description('The key rotation policy.')
-  rotationPolicy: object?
+  rotationPolicy: rotationPolicyType?
+}
+
+@description('The type of the key.')
+type ktyType = 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM'
+
+@description('The elliptic curve name.')
+type curveNameType = 'P-256' | 'P-256K' | 'P-384' | 'P-521'
+
+@description('Defines the attributes for the rotation policy')
+type rotationPolicyAttributesType = {
+  @description('The expiry time for the key')
+  expiryTime: string
+}
+
+@description('Defines the action for a lifetime action')
+type lifetimeActionActionType = {
+  @description('The type of action to take')
+  type: 'Rotate' | 'Notify'
+}
+
+@description('Defines the trigger for a lifetime action')
+type lifetimeActionTriggerType = {
+  @description('The time before expiry to trigger the action')
+  timeBeforeExpiry: string
+}
+
+@description('Defines a single lifetime action')
+type lifetimeActionType = {
+  @description('The action to take')
+  action: lifetimeActionActionType
+
+  @description('The trigger for the action')
+  trigger: lifetimeActionTriggerType
+}
+
+@description('Defines the rotation policy for a key')
+type rotationPolicyType = {
+  @description('The attributes of the rotation policy')
+  attributes: rotationPolicyAttributesType
+
+  @description('The lifetime actions for the rotation policy')
+  lifetimeActions: lifetimeActionType[]
 }


### PR DESCRIPTION
This pull request includes changes to the `Scenarios/Secure-Baseline/bicepWithAVM/03-Supporting-Services/modules/key-vault/types.bicep` file. The most significant changes involve the restructuring of the `keyType` and the addition of several new types related to key rotation policy.

Key type restructuring:

* Removed `curveNameType` and `ktyType` from the global scope and moved them inside `keyType`. This change ensures that these types are more closely associated with the `keyType` where they are used.

Addition of new types:

* Added `rotationPolicyAttributesType` to define the attributes for the rotation policy, including the expiry time for the key.
* Added `lifetimeActionActionType` to define the action for a lifetime action, such as 'Rotate' or 'Notify'.
* Added `lifetimeActionTriggerType` to define the trigger for a lifetime action, including the time before expiry to trigger the action.
* Added `lifetimeActionType` to define a single lifetime action, including the action to take and the trigger for the action.
* Added `rotationPolicyType` to define the rotation policy for a key, including the attributes of the rotation policy and the lifetime actions for the rotation policy.

These changes enhance the flexibility and clarity of the key rotation policy by providing more detailed types and better organizing the types related to `keyType`.