### PR TITLE
Add 'hash' variable to the automatic deployment

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
@@ -72,8 +72,10 @@ display_message info "Spoke workload name: $SPOKE_WORKLOAD_NAME"
 display_message info "Environment: $ENVIRONMENT"
 display_message info "Location: $LOCATION"
 if [ -z "$HASH" ]; then
+    HASH_WITH_HYPHEN=""
     display_message info "Hash: not using hash"
 else
+    HASH_WITH_HYPHEN=-$HASH
     display_message info "Hash: $HASH"
 fi
 display_blank_line
@@ -83,7 +85,7 @@ display_blank_line
 # ---------------------------------------------------------------------------- #
 
 # Deploy the hub resources
-_hub_deployment_name="$HUB_WORKLOAD_NAME-$_environment_lower_case-$_short_location"
+_hub_deployment_name="$HUB_WORKLOAD_NAME-$_environment_lower_case-$_short_location$HASH_WITH_HYPHEN"
 display_progress "Deploying the hub resources"
 display_message info "Deployment name: $_hub_deployment_name"
 az deployment sub create \
@@ -114,7 +116,7 @@ display_blank_line
 # ---------------------------------------------------------------------------- #
 
 # Deploy the spoke network resources
-_spoke_network_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location"
+_spoke_network_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location$HASH_WITH_HYPHEN"
 display_progress "Deploying the spoke network resources"
 display_message info "Deployment name: $_spoke_network_deployment_name"
 az deployment sub create \
@@ -145,7 +147,7 @@ display_blank_line
 # Link spoke virtual network to private DNS zones
 display_progress "Linking spoke virtual network to private DNS zones"
 az deployment group create \
-    --name "$SPOKE_WORKLOAD_NAME-$_environment_lower_case-link-keyvault-private-dns-to-spoke-network" \
+    --name "$SPOKE_WORKLOAD_NAME-$_environment_lower_case-link-keyvault-private-dns-to-spoke-network$HASH_WITH_HYPHEN" \
     --resource-group $HUB_RG_NAME \
     --template-file "./02-Spoke/link-private-dns-to-network.bicep" \
     --parameters \
@@ -155,7 +157,7 @@ az deployment group create \
         privateDnsZoneName=$KEY_VAULT_PRIVATE_DNS_ZONE_NAME \
         virtualNetworkResourceId=$SPOKE_VNET_ID    
 az deployment group create \
-    --name "$SPOKE_WORKLOAD_NAME-$_environment_lower_case-link-acr-private-dns-to-spoke-network" \
+    --name "$SPOKE_WORKLOAD_NAME-$_environment_lower_case-link-acr-private-dns-to-spoke-network$HASH_WITH_HYPHEN" \
     --resource-group $HUB_RG_NAME \
     --template-file "./02-Spoke/link-private-dns-to-network.bicep" \
     --parameters \
@@ -168,7 +170,7 @@ display_progress "Spoke virtual network linked to private DNS zones"
 display_blank_line
 
 # Deploy the supporting services in the spoke
-_spoke_services_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location-services"
+_spoke_services_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location-services$HASH_WITH_HYPHEN"
 display_progress "Deploying the supporting services in the spoke"
 display_message info "Deployment name: $_spoke_services_deployment_name"
 az deployment group create \
@@ -213,7 +215,7 @@ display_blank_line
 
 # Deploy ARO Cluster
 display_progress "Deploying Azure Red Hat OpenShift cluster"
-_aro_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location-aro"
+_aro_deployment_name="$SPOKE_WORKLOAD_NAME-$_environment_lower_case-$_short_location-aro$HASH_WITH_HYPHEN"
 display_message info "Deployment name: $_aro_deployment_name"
 az deployment group create \
     --name $_aro_deployment_name \

--- a/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
@@ -62,7 +62,7 @@ HUB_WORKLOAD_NAME=${HUB_WORKLOAD_NAME:-"hub"}
 SPOKE_WORKLOAD_NAME=${SPOKE_WORKLOAD_NAME:-"aro-lza"}
 ENVIRONMENT=${ENVIRONMENT:-"DEV"}
 LOCATION=${LOCATION:-"eastus"}
-HASH=${HASH:-$((RANDOM % 1000))$((RANDOM % 1000))$((RANDOM % 1000))}
+HASH=${HASH:-""}
 
 _environment_lower_case=$(echo $ENVIRONMENT | tr '[:upper:]' '[:lower:]')
 _short_location=$(get_short_location $LOCATION)
@@ -71,7 +71,11 @@ display_message info "Hub workload name: $HUB_WORKLOAD_NAME"
 display_message info "Spoke workload name: $SPOKE_WORKLOAD_NAME"
 display_message info "Environment: $ENVIRONMENT"
 display_message info "Location: $LOCATION"
-display_message info "Hash: $HASH"
+if [ -z "$HASH" ]; then
+    display_message info "Hash: not using hash"
+else
+    display_message info "Hash: $HASH"
+fi
 display_blank_line
 
 # ---------------------------------------------------------------------------- #

--- a/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# TODO add hash
-
 # ---------------------------------------------------------------------------- #
 #                                   FUNCTIONS                                  #
 # ---------------------------------------------------------------------------- #
@@ -64,6 +62,7 @@ HUB_WORKLOAD_NAME=${HUB_WORKLOAD_NAME:-"hub"}
 SPOKE_WORKLOAD_NAME=${SPOKE_WORKLOAD_NAME:-"aro-lza"}
 ENVIRONMENT=${ENVIRONMENT:-"DEV"}
 LOCATION=${LOCATION:-"eastus"}
+HASH=${HASH:-$((RANDOM % 1000))$((RANDOM % 1000))$((RANDOM % 1000))}
 
 _environment_lower_case=$(echo $ENVIRONMENT | tr '[:upper:]' '[:lower:]')
 _short_location=$(get_short_location $LOCATION)
@@ -72,6 +71,7 @@ display_message info "Hub workload name: $HUB_WORKLOAD_NAME"
 display_message info "Spoke workload name: $SPOKE_WORKLOAD_NAME"
 display_message info "Environment: $ENVIRONMENT"
 display_message info "Location: $LOCATION"
+display_message info "Hash: $HASH"
 display_blank_line
 
 # ---------------------------------------------------------------------------- #
@@ -88,6 +88,7 @@ az deployment sub create \
     --template-file "./01-Hub/main.bicep" \
     --parameters ./01-Hub/main.bicepparam \
     --parameters \
+        hash=$HASH \
         workloadName=$HUB_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         location=$LOCATION
@@ -118,6 +119,7 @@ az deployment sub create \
     --template-file "./02-Spoke/main.bicep" \
     --parameters ./02-Spoke/main.bicepparam \
     --parameters \
+        hash=$HASH \
         workloadName=$SPOKE_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         location=$LOCATION \
@@ -143,6 +145,7 @@ az deployment group create \
     --resource-group $HUB_RG_NAME \
     --template-file "./02-Spoke/link-private-dns-to-network.bicep" \
     --parameters \
+        hash=$HASH \
         workloadName=$SPOKE_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         privateDnsZoneName=$KEY_VAULT_PRIVATE_DNS_ZONE_NAME \
@@ -152,6 +155,7 @@ az deployment group create \
     --resource-group $HUB_RG_NAME \
     --template-file "./02-Spoke/link-private-dns-to-network.bicep" \
     --parameters \
+        hash=$HASH \
         workloadName=$SPOKE_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         privateDnsZoneName=$ACR_PRIVATE_DNS_ZONE_NAME \
@@ -169,6 +173,7 @@ az deployment group create \
     --template-file "./03-Supporting-Services/main.bicep" \
     --parameters ./03-Supporting-Services/main.bicepparam \
     --parameters \
+        hash=$HASH \
         workloadName=$SPOKE_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         location=$LOCATION \
@@ -212,6 +217,7 @@ az deployment group create \
     --template-file "./04-ARO/main.bicep" \
     --parameters ./04-ARO/main.bicepparam \
     --parameters \
+        hash=$HASH \
         workloadName=$SPOKE_WORKLOAD_NAME \
         env=$ENVIRONMENT \
         location=$LOCATION \


### PR DESCRIPTION
This pull request mainly introduces a new `HASH` variable to the `deploy.sh` script in the `Scenarios/Secure-Baseline/bicepWithAVM` directory. The `HASH` variable is randomly generated and then used as a parameter in multiple Azure deployment commands throughout the script. Additionally, a TODO comment about adding a hash has been removed.

The most important changes are:

* [`Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh`](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eL3-L4): Removed a TODO comment about adding a hash.
* [`Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh`](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR65): Added a new `HASH` variable that generates a random value.
* [`Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh`](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR74): Displayed the value of the `HASH` variable in the console.
* [`Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh`](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR91): Used the `HASH` variable as a parameter in multiple Azure deployment commands. [[1]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR91) [[2]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR122) [[3]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR148) [[4]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR158) [[5]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR176) [[6]](diffhunk://#diff-9aafd2d2f383e8323effe3e58b99b5d3eb624e937249b965b981ba0b951b5e3eR220)