### PR TITLE
Add possibility of adding additional subnets to the Hub

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
@@ -58,8 +58,8 @@ param resourceGroupName string = generateResourceName('resourceGroup', workloadN
 @description('The name of the virtual network for the hub. Defaults to the naming convention `<abbreviation-virtual-network>-<workload>-<lower-case-env>-<location-short>[-<hash>]`.')
 param virtualNetworkName string = generateResourceName('virtualNetwork', workloadName, env, location, null, hash)
 
-@description('The CIDR for the virtual network. Defaults to `10.0.0.0/16`.')
-param virtualNetworkAddressPrefix string = '10.0.0.0/16'
+@description('The address prefixes for the hub virtual network. Defaults to ["10.1.0.0/16"].')
+param virtualNetworkAddressPrefixes array = ['10.0.0.0/16']
 
 @description('The DNS servers (Optional).')
 param dnsServers array?
@@ -213,7 +213,7 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:0.1.8' = {
     location: location
     tags: tags
     enableTelemetry: enableAvmTelemetry
-    addressPrefixes: [virtualNetworkAddressPrefix]
+    addressPrefixes: virtualNetworkAddressPrefixes
     dnsServers: dnsServers
     subnets: allSubnets
     diagnosticSettings: diagnosticsSettings

--- a/Scenarios/Secure-Baseline/bicepWithAVM/02-Spoke/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/02-Spoke/main.bicep
@@ -67,8 +67,8 @@ param hubVirtualNetworkResourceId string
 @maxLength(64)
 param virtualNetworkName string = generateResourceName('virtualNetwork', workloadName, env, location, null, hash)
 
-@description('The CIDR for the spoke virtual network. Defaults to 10.1.0.0/16.')
-param virtualNetworkAddressPrefix string = '10.1.0.0/16'
+@description('The address prefixes for the spoke virtual network. Defaults to ["10.1.0.0/16"].')
+param virtualNetworkAddressPrefixes array = ['10.1.0.0/16']
 
 @description('The DNS server array (Optional).')
 param dnsServers array?
@@ -189,7 +189,7 @@ var predefinedSubnets = [
   }
 ]
 
-var subnets = concat(predefinedSubnets, otherSubnets == null ? [] : otherSubnets!)
+var subnets = concat(predefinedSubnets, otherSubnets ?? [])
 
 /* ------------------------------- Monitoring ------------------------------- */
 
@@ -219,7 +219,7 @@ module virtualNetwork 'br/public:avm/res/network/virtual-network:0.1.8' = {
     location: location
     tags: tags
     enableTelemetry: enableAvmTelemetry
-    addressPrefixes: [virtualNetworkAddressPrefix]
+    addressPrefixes: virtualNetworkAddressPrefixes
     dnsServers: dnsServers
     peerings: peerings
     subnets: subnets

--- a/Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicepparam
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicepparam
@@ -13,3 +13,5 @@ param servicePrincipalClientSecret =  '<servicePrincipalClientSecret>'
 param servicePrincipalObjectId =  '<servicePrincipalObjectId>'
 
 param aroResourceProviderServicePrincipalObjectId =  '<aroResourceProviderServicePrincipalObjectId>'
+
+param aroClusterVersion =  '4.12.25'

--- a/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
@@ -279,7 +279,7 @@ display_blank_line
 
 # Deploy Service Principal
 display_progress "Creating a service principal for the workload"
-SP=$(az ad sp create-for-rbac --name "sp-$WORKLOAD_NAME-$_environment_lower_case-$_short_location")
+SP=$(az ad sp create-for-rbac --name "sp-$WORKLOAD_NAME-$_environment_lower_case-$_short_location$HASH_WITH_HYPHEN")
 SP_CLIENT_ID=$(echo $SP | jq -r '.appId')
 SP_CLIENT_SECRET=$(echo $SP | jq -r '.password')
 SP_OBJECT_ID=$(az ad sp show --id $SP_CLIENT_ID --query "id" -o tsv)


### PR DESCRIPTION
This pull request to `Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep` introduces changes to support additional subnets in the virtual network configuration. The most important changes include adding a new parameter for additional subnets, modifying existing subnet variables to accommodate the new parameter, and updating the virtual network module to use the combined list of subnets.

Support for additional subnets:

* Added a new optional parameter `additionalSubnets` to specify extra subnets. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)

Variable updates:

* Renamed the existing `subnets` variable to `defaultSubnets` to distinguish between default and additional subnets. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)
* Created a new variable `allSubnets` that concatenates `defaultSubnets` and `additionalSubnets`. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)

Module updates:

* Updated the `virtualNetwork` module to use the new `allSubnets` variable instead of the original `subnets` variable. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)