### PR TITLE
Fix devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
       "ghcr.io/devcontainers/features/azure-cli:1": {},
       "ghcr.io/rchaganti/vsc-devcontainer-features/azurebicep:1": {},
       "ghcr.io/devcontainers/features/terraform:1": {},
-      "ghcr.io/devcontainers-contrib/features/terrascan:1": {},
       "ghcr.io/devcontainers/features/dotnet:2": {},
       "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
       "ghcr.io/paul-gilber/devcontainer-features/openshift-cli-homebrew:1": {}


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change removes the `terrascan` feature from the list of included features.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L8): Removed the `ghcr.io/devcontainers-contrib/features/terrascan:1` feature from the list.