### PR TITLE
Update firewall to standard and add rules to deploy the sample app

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/firewall/afwp-rule-collection-groups-sample-app.jsonc
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/firewall/afwp-rule-collection-groups-sample-app.jsonc
@@ -1,0 +1,34 @@
+[
+  {
+    "name": "<FIREWALL_POLICY_RULE_GROUP_NAME_PLACEHOLDER>",
+    "priority": 200,
+    "ruleCollections": [
+      {
+        "name": "AllowSampleApp",
+        "priority": 201,
+        "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+        "action": {
+          "type": "Allow"
+        },
+        "rules": [
+          {
+            "name": "AllowRegistries",
+            "ruleType": "ApplicationRule",
+            "protocols": [
+              {
+                "protocolType": "Https",
+                "port": 443
+              }
+            ],
+            "sourceAddresses": ["*"],
+            "targetFqdns": [
+              "*.pkg.dev",
+              "registry.k8s.io",
+              "prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
@@ -303,7 +303,7 @@ module firewall 'br/public:avm/res/network/azure-firewall:0.3.0' = {
     }
     managementIPResourceID: firewallManagementPublicIp.outputs.resourceId
     threatIntelMode: 'Deny'
-    azureSkuTier: 'Basic'
+    azureSkuTier: 'Standard'
     zones: firewallAvailabilityZone
     firewallPolicyId: firewallPolicy.outputs.resourceId
     applicationRuleCollections: []
@@ -321,9 +321,11 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:0.1.3' = {
     location: location
     tags: tags
     enableTelemetry: enableAvmTelemetry
-    tier: 'Basic'
+    tier: 'Standard'
     threatIntelMode: 'Alert'
     ruleCollectionGroups: firewallPolicyRuleCollectionGroups
+    servers: ['168.63.129.16']
+    enableProxy: true
   }
 }
 

--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
@@ -117,6 +117,9 @@ param firewallPolicyName string = generateResourceName('firewallPolicy', workloa
 @description('The name of the firewall policy rule group. Defaults to the naming convention `<abbreviation-firewall-policy-rule-group>-<workload>-<lower-case-env>-<location-short>[-<hash>]`.')
 param firewallPolicyRuleGroupName string = generateResourceName('firewallPolicyRuleGroup', workloadName, env, location, null, hash)
 
+@description('Flag to deploy the firewall policy rule group for the sample app. Defaults to true. It uses the `afwp-rule-collection-groups-sample-app.jsonc` file.')
+param deployFirewallPolicyRuleGroupSampleApp bool = true
+
 /* --------------------------------- Bastion -------------------------------- */
 
 @description('The name of the bastion. Defaults to the naming convention `<abbreviation-bastion>-<workload>-<lower-case-env>-<location-short>[-<hash>]`.')
@@ -178,7 +181,9 @@ var acrPrivateDnsZoneVnetLinks = linkAcrDnsZoneToHubVnet ? [
 
 /* -------------------------------- Firewall -------------------------------- */
 
-var firewallPolicyRuleCollectionGroups = [ for ruleCollectionGroup in loadJsonContent('firewall/afwp-rule-collection-groups.jsonc') : {
+var firewallPolicyRuleGroupFile = deployFirewallPolicyRuleGroupSampleApp ? loadJsonContent('firewall/afwp-rule-collection-groups-sample-app.jsonc') : loadJsonContent('firewall/afwp-rule-collection-groups.jsonc')
+
+var firewallPolicyRuleCollectionGroups = [ for ruleCollectionGroup in firewallPolicyRuleGroupFile : {
   name: ruleCollectionGroup.name == '<FIREWALL_POLICY_RULE_GROUP_NAME_PLACEHOLDER>' ? firewallPolicyRuleGroupName : ruleCollectionGroup.name
   priority: ruleCollectionGroup.priority
   ruleCollections: ruleCollectionGroup.ruleCollections

--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
@@ -324,7 +324,6 @@ module firewallPolicy 'br/public:avm/res/network/firewall-policy:0.1.3' = {
     tier: 'Standard'
     threatIntelMode: 'Alert'
     ruleCollectionGroups: firewallPolicyRuleCollectionGroups
-    servers: ['168.63.129.16']
     enableProxy: true
   }
 }

--- a/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh
@@ -279,7 +279,7 @@ display_blank_line
 
 # Deploy Service Principal
 display_progress "Creating a service principal for the workload"
-SP=$(az ad sp create-for-rbac --name "sp-$WORKLOAD_NAME-$_environment_lower_case-$_short_location$HASH_WITH_HYPHEN")
+SP=$(az ad sp create-for-rbac --name "sp-$HUB_WORKLOAD_NAME-$_environment_lower_case-$_short_location$HASH_WITH_HYPHEN")
 SP_CLIENT_ID=$(echo $SP | jq -r '.appId')
 SP_CLIENT_SECRET=$(echo $SP | jq -r '.password')
 SP_OBJECT_ID=$(az ad sp show --id $SP_CLIENT_ID --query "id" -o tsv)


### PR DESCRIPTION
This pull request introduces several changes to the `Scenarios/Secure-Baseline/bicepWithAVM/01-Hub` directory to enhance the firewall policy configuration and deployment process. The main changes include adding a new sample application firewall policy rule group, updating parameter definitions, and modifying the firewall and firewall policy modules to use the `Standard` tier.

### Firewall Policy Enhancements:

* Added a new sample application firewall policy rule group in `afwp-rule-collection-groups-sample-app.jsonc` to allow specific registries. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/firewall/afwp-rule-collection-groups-sample-app.jsonc`)

### Parameter and Variable Updates:

* Introduced a new parameter `deployFirewallPolicyRuleGroupSampleApp` to control the deployment of the sample app firewall policy rule group. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)
* Updated the `firewallPolicyRuleCollectionGroups` variable to conditionally load the sample app firewall policy rule group based on the new parameter. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)

### Module Configuration Changes:

* Changed the `azureSkuTier` for the firewall module from `Basic` to `Standard`. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)
* Updated the `tier` for the firewall policy module from `Basic` to `Standard` and enabled the proxy. (`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`)

### Miscellaneous:

* Corrected the service principal creation command to use the `HUB_WORKLOAD_NAME` instead of `WORKLOAD_NAME` in the deployment script. (`Scenarios/Secure-Baseline/bicepWithAVM/deploy.sh`)