### PR TITLE
Remove location from telemetry deployment

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicep
@@ -353,7 +353,6 @@ module assignReaderRoleToAROResourceProviderSPForDiskEncryptionSet 'br/public:av
 @description('Microsoft telemetry deployment.')
 #disable-next-line no-deployments-resources
 resource telemetrydeployment 'Microsoft.Resources/deployments@2021-04-01' = if (enableTelemetry) {
-  location: location
   name: telemetryId
   properties: {
     mode: 'Incremental'


### PR DESCRIPTION
This pull request includes a change to the `Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicep` file to improve the telemetry deployment configuration.

Configuration improvements:

* [`Scenarios/Secure-Baseline/bicepWithAVM/04-ARO/main.bicep`](diffhunk://#diff-11bec0434e3bac1af8fb134c3d8d567884f0c48eaec15ad0204daa1950baed65L356): Removed the unnecessary `location` property from the `telemetrydeployment` resource definition.