### PR TITLE
Fix bug in the container registry DNS zone name

### DIFF
--- a/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
+++ b/Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep
@@ -168,7 +168,7 @@ var keyVaultPrivateDnsZoneVnetLinks = linkKeyvaultDnsZoneToHubVnet ? [
   }
 ] : []
 
-var acrPrivateDnsZoneName = 'private${environment().suffixes.acrLoginServer}'
+var acrPrivateDnsZoneName = 'privatelink${environment().suffixes.acrLoginServer}'
 
 var acrPrivateDnsZoneVnetLinks = linkAcrDnsZoneToHubVnet ? [
   {


### PR DESCRIPTION
This pull request includes a small but important change to the `main.bicep` file in the `Scenarios/Secure-Baseline/bicepWithAVM/01-Hub` directory. The change updates the naming convention for the ACR private DNS zone.

* [`Scenarios/Secure-Baseline/bicepWithAVM/01-Hub/main.bicep`](diffhunk://#diff-c6319c8fc6a63403ab1d0a860e885c6a54d1802a45bc973a523c372418d0519aL171-R171): Updated the `acrPrivateDnsZoneName` variable to use the `privatelink` prefix instead of `private`.