### PR TITLE
Change default aro version for Bicep

### DIFF
--- a/Scenarios/Secure-Baseline/bicep/04-ARO/main.bicepparam
+++ b/Scenarios/Secure-Baseline/bicep/04-ARO/main.bicepparam
@@ -14,4 +14,4 @@ param servicePrincipalObjectId =  '<servicePrincipalObjectId>'
 
 param aroResourceProviderServicePrincipalObjectId =  '<aroResourceProviderServicePrincipalObjectId>'
 
-param aroClusterVersion =  '4.12.60'
+param aroClusterVersion =  '4.14.38'


### PR DESCRIPTION
This pull request updates the `aroClusterVersion` parameter in the `main.bicepparam` file to reflect a newer version of the ARO cluster.

* [`Scenarios/Secure-Baseline/bicep/04-ARO/main.bicepparam`](diffhunk://#diff-7df4e4e991ac08832c192d73e4b1debdab8182e4089d9b9da615583cc0817f2bL17-R17): Updated the `aroClusterVersion` parameter from `'4.12.60'` to `'4.14.38'` to use the latest supported version.