### PR TITLE
Update main.bicep to remove not needed condition

### DIFF
--- a/Scenarios/Secure-Baseline/bicep/04-ARO/main.bicep
+++ b/Scenarios/Secure-Baseline/bicep/04-ARO/main.bicep
@@ -245,28 +245,8 @@ resource aroCluster 'Microsoft.RedHatOpenShift/openShiftClusters@2023-11-22' = {
 
 /* ----------------------------- Role Assignment ---------------------------- */
 
-// resource assignContributorRoleToSPForApplicationResourceGroup 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-//   name: guid(servicePrincipalObjectId, resourceGroup().id, contributorRoleResourceId)
-//   scope: resourceGroup()
-//   properties: {
-//     principalId: servicePrincipalObjectId
-//     roleDefinitionId: contributorRoleResourceId
-//     principalType: 'ServicePrincipal'
-//   }
-// }
-
-// resource assignUserAccessAdministratorRoleToSPForApplicationResourceGroup 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-//   name: guid(servicePrincipalObjectId, resourceGroup().id, userAccessAdministratorRoleResourceId)
-//   scope: resourceGroup()
-//   properties: {
-//     principalId: servicePrincipalObjectId
-//     roleDefinitionId: userAccessAdministratorRoleResourceId
-//     principalType: 'ServicePrincipal'
-//   }
-// }
-
 // Spoke Virtual Network
-module assignNetworkContributorRoleToSPForVirtualNetwork 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.1' = if (useUdr) {
+module assignNetworkContributorRoleToSPForVirtualNetwork 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.1' = {
   name: take('${deployment().name}-sp-spoke-vnet-net-contributor', 64)
   params: {
     principalId: servicePrincipalObjectId
@@ -279,7 +259,7 @@ module assignNetworkContributorRoleToSPForVirtualNetwork 'br/public:avm/ptn/auth
   }
 }
 
-module assignNetworkContributorRoleToAROResourceProviderSPForVirtualNetwork 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.1' = if (useUdr) {
+module assignNetworkContributorRoleToAROResourceProviderSPForVirtualNetwork 'br/public:avm/ptn/authorization/resource-role-assignment:0.1.1' = {
   name: take('${deployment().name}-aro-rp-spoke-vnet-net-contributor', 64)
   params: {
     principalId: aroResourceProviderServicePrincipalObjectId


### PR DESCRIPTION
This pull request makes adjustments to role assignments and module conditions in the `Scenarios/Secure-Baseline/bicep/04-ARO/main.bicep` file. The most notable changes involve removing commented-out role assignment resources and simplifying conditional logic for network contributor role assignments.

Role assignment changes:

* Removed commented-out role assignment resources for `assignContributorRoleToSPForApplicationResourceGroup` and `assignUserAccessAdministratorRoleToSPForApplicationResourceGroup`, which were previously targeting the application resource group. These were likely redundant or deprecated.

Module condition simplifications:

* Updated the `assignNetworkContributorRoleToSPForVirtualNetwork` module to remove the conditional `if (useUdr)` clause, ensuring the module is always deployed.
* Similarly, updated the `assignNetworkContributorRoleToAROResourceProviderSPForVirtualNetwork` module to remove the conditional `if (useUdr)` clause, making it unconditional as well.